### PR TITLE
Dropping all world permissions as they are not needed

### DIFF
--- a/docs/docker-compose-rabbitmq-db2/README.md
+++ b/docs/docker-compose-rabbitmq-db2/README.md
@@ -153,7 +153,7 @@ see [Environment Variables](https://github.com/Senzing/knowledge-base/blob/maste
 
     ```console
     sudo mkdir -p ${RABBITMQ_DIR}
-    sudo chmod 777 ${RABBITMQ_DIR}
+    sudo chmod 770 ${RABBITMQ_DIR}
     ```
 
 ### EULA

--- a/docs/docker-compose-rabbitmq-mssql/README.md
+++ b/docs/docker-compose-rabbitmq-mssql/README.md
@@ -157,7 +157,7 @@ see [Environment Variables](https://github.com/Senzing/knowledge-base/blob/maste
 
     ```console
     sudo mkdir -p ${RABBITMQ_DIR}
-    sudo chmod 777 ${RABBITMQ_DIR}
+    sudo chmod 770 ${RABBITMQ_DIR}
     ```
 
 ### EULA

--- a/docs/docker-compose-rabbitmq-mysql/README.md
+++ b/docs/docker-compose-rabbitmq-mysql/README.md
@@ -165,7 +165,7 @@ see [Environment Variables](https://github.com/Senzing/knowledge-base/blob/maste
 
     ```console
     sudo mkdir -p ${RABBITMQ_DIR}
-    sudo chmod 777 ${RABBITMQ_DIR}
+    sudo chmod 770 ${RABBITMQ_DIR}
     ```
 
 ### EULA

--- a/docs/docker-compose-rabbitmq-postgresql-advanced/README.md
+++ b/docs/docker-compose-rabbitmq-postgresql-advanced/README.md
@@ -154,7 +154,7 @@ see [Environment Variables](https://github.com/Senzing/knowledge-base/blob/maste
 
     ```console
     sudo mkdir -p ${RABBITMQ_DIR}
-    sudo chmod 777 ${RABBITMQ_DIR}
+    sudo chmod 770 ${RABBITMQ_DIR}
     ```
 
 ### EULA

--- a/docs/docker-compose-rabbitmq-postgresql/README.md
+++ b/docs/docker-compose-rabbitmq-postgresql/README.md
@@ -153,7 +153,7 @@ see [Environment Variables](https://github.com/Senzing/knowledge-base/blob/maste
 
     ```console
     sudo mkdir -p ${RABBITMQ_DIR}
-    sudo chmod 777 ${RABBITMQ_DIR}
+    sudo chmod 770 ${RABBITMQ_DIR}
     ```
 
 ### EULA

--- a/docs/docker-compose-rabbitmq-sqlite-advanced/README.md
+++ b/docs/docker-compose-rabbitmq-sqlite-advanced/README.md
@@ -151,7 +151,7 @@ see [Environment Variables](https://github.com/Senzing/knowledge-base/blob/maste
 
     ```console
     sudo mkdir -p ${RABBITMQ_DIR}
-    sudo chmod 777 ${RABBITMQ_DIR}
+    sudo chmod 770 ${RABBITMQ_DIR}
     ```
 
 ### EULA

--- a/docs/docker-compose-rabbitmq-sqlite-cluster/README.md
+++ b/docs/docker-compose-rabbitmq-sqlite-cluster/README.md
@@ -151,7 +151,7 @@ see [Environment Variables](https://github.com/Senzing/knowledge-base/blob/maste
 
     ```console
     sudo mkdir -p ${RABBITMQ_DIR}
-    sudo chmod 777 ${RABBITMQ_DIR}
+    sudo chmod 770 ${RABBITMQ_DIR}
     ```
 
 ### EULA

--- a/docs/docker-compose-rabbitmq-sqlite-governor/README.md
+++ b/docs/docker-compose-rabbitmq-sqlite-governor/README.md
@@ -159,7 +159,7 @@ see [Environment Variables](https://github.com/Senzing/knowledge-base/blob/maste
 
     ```console
     sudo mkdir -p ${RABBITMQ_DIR}
-    sudo chmod 777 ${RABBITMQ_DIR}
+    sudo chmod 770 ${RABBITMQ_DIR}
     ```
 
 ### EULA

--- a/docs/docker-compose-rabbitmq-sqlite/README.md
+++ b/docs/docker-compose-rabbitmq-sqlite/README.md
@@ -150,7 +150,7 @@ see [Environment Variables](https://github.com/Senzing/knowledge-base/blob/maste
 
     ```console
     sudo mkdir -p ${RABBITMQ_DIR}
-    sudo chmod 777 ${RABBITMQ_DIR}
+    sudo chmod 770 ${RABBITMQ_DIR}
     ```
 
 ### EULA


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #62 

## Why was change needed

World writable permissions are not necessary and a potential security issue

## What does change improve

Removes all world permissions from the documentation
