### PR TITLE
#133 removed entity-search-web-app-console from formation examples

### DIFF
--- a/docs/docker-compose-kafka-db2/README.md
+++ b/docs/docker-compose-kafka-db2/README.md
@@ -254,7 +254,6 @@ This docker formation brings up the following docker containers:
 1. *[obsidiandynamics/kafdrop](https://hub.docker.com/r/obsidiandynamics/kafdrop)*
 1. *[senzing/console](https://github.com/Senzing/docker-senzing-console)*
 1. *[senzing/db2-driver-installer](https://github.com/Senzing/docker-db2-driver-installer)*
-1. *[senzing/entity-web-search-app-console](https://github.com/Senzing/entity-search-web-app-console)*
 1. *[senzing/entity-web-search-app](https://github.com/Senzing/entity-search-web-app)*
 1. *[senzing/init-container](https://github.com/Senzing/docker-init-container)*
 1. *[senzing/redoer](https://github.com/Senzing/redoer)*

--- a/docs/docker-compose-kafka-mssql/README.md
+++ b/docs/docker-compose-kafka-mssql/README.md
@@ -266,7 +266,6 @@ This docker formation brings up the following docker containers:
 1. *[obsidiandynamics/kafdrop](https://hub.docker.com/r/obsidiandynamics/kafdrop)*
 1. *[senzing/adminer](https://github.com/Senzing/docker-adminer)*
 1. *[senzing/console](https://github.com/Senzing/docker-senzing-console)*
-1. *[senzing/entity-web-search-app-console](https://github.com/Senzing/entity-search-web-app-console)*
 1. *[senzing/entity-web-search-app](https://github.com/Senzing/entity-search-web-app)*
 1. *[senzing/init-container](https://github.com/Senzing/docker-init-container)*
 1. *[senzing/jupyter](https://github.com/Senzing/docker-jupyter)*

--- a/docs/docker-compose-kafka-mysql/README.md
+++ b/docs/docker-compose-kafka-mysql/README.md
@@ -245,7 +245,6 @@ This docker formation brings up the following docker containers:
 1. *[obsidiandynamics/kafdrop](https://hub.docker.com/r/obsidiandynamics/kafdrop)*
 1. *[phpmyadmin/phpmyadmin](https://github.com/phpmyadmin/docker)*
 1. *[senzing/console](https://github.com/Senzing/docker-senzing-console)*
-1. *[senzing/entity-web-search-app-console](https://github.com/Senzing/entity-search-web-app-console)*
 1. *[senzing/entity-web-search-app](https://github.com/Senzing/entity-search-web-app)*
 1. *[senzing/redoer](https://github.com/Senzing/redoer)*
 1. *[senzing/senzing-poc-server](https://github.com/Senzing/senzing-poc-server)*

--- a/docs/docker-compose-kafka-postgresql-advanced/README.md
+++ b/docs/docker-compose-kafka-postgresql-advanced/README.md
@@ -331,7 +331,6 @@ This docker formation brings up the following docker containers:
 1. *[dpage/pgadmin4](https://hub.docker.com/r/dpage/pgadmin4)*
 1. *[obsidiandynamics/kafdrop](https://hub.docker.com/r/obsidiandynamics/kafdrop)*
 1. *[senzing/console](https://github.com/Senzing/docker-senzing-console)*
-1. *[senzing/entity-web-search-app-console](https://github.com/Senzing/entity-search-web-app-console)*
 1. *[senzing/entity-web-search-app](https://github.com/Senzing/entity-search-web-app)*
 1. *[senzing/jupyter](https://github.com/Senzing/docker-jupyter)*
 1. *[senzing/redoer](https://github.com/Senzing/redoer)*

--- a/docs/docker-compose-kafka-postgresql/README.md
+++ b/docs/docker-compose-kafka-postgresql/README.md
@@ -263,7 +263,6 @@ This docker formation brings up the following docker containers:
 1. *[dpage/pgadmin4](https://hub.docker.com/r/dpage/pgadmin4)*
 1. *[obsidiandynamics/kafdrop](https://hub.docker.com/r/obsidiandynamics/kafdrop)*
 1. *[senzing/console](https://github.com/Senzing/docker-senzing-console)*
-1. *[senzing/entity-web-search-app-console](https://github.com/Senzing/entity-search-web-app-console)*
 1. *[senzing/entity-web-search-app](https://github.com/Senzing/entity-search-web-app)*
 1. *[senzing/jupyter](https://github.com/Senzing/docker-jupyter)*
 1. *[senzing/redoer](https://github.com/Senzing/redoer)*

--- a/docs/docker-compose-kafka-sqlite/README.md
+++ b/docs/docker-compose-kafka-sqlite/README.md
@@ -258,7 +258,6 @@ This docker formation brings up the following docker containers:
 1. *[coleifer/sqlite-web](https://github.com/coleifer/sqlite-web)*
 1. *[obsidiandynamics/kafdrop](https://hub.docker.com/r/obsidiandynamics/kafdrop)*
 1. *[senzing/console](https://github.com/Senzing/docker-senzing-console)*
-1. *[senzing/entity-web-search-app-console](https://github.com/Senzing/entity-search-web-app-console)*
 1. *[senzing/entity-web-search-app](https://github.com/Senzing/entity-search-web-app)*
 1. *[senzing/jupyter](https://github.com/Senzing/docker-jupyter)*
 1. *[senzing/redoer](https://github.com/Senzing/redoer)*

--- a/docs/docker-compose-rabbitmq-db2/README.md
+++ b/docs/docker-compose-rabbitmq-db2/README.md
@@ -254,7 +254,6 @@ This docker formation brings up the following docker containers:
 1. *[ibmcom/db2](https://hub.docker.com/r/ibmcom/db2)*
 1. *[senzing/console](https://github.com/Senzing/docker-senzing-console)*
 1. *[senzing/db2-driver-installer](https://github.com/Senzing/docker-db2-driver-installer)*
-1. *[senzing/entity-web-search-app-console](https://github.com/Senzing/entity-search-web-app-console)*
 1. *[senzing/entity-web-search-app](https://github.com/Senzing/entity-search-web-app)*
 1. *[senzing/init-container](https://github.com/Senzing/docker-init-container)*
 1. *[senzing/redoer](https://github.com/Senzing/redoer)*

--- a/docs/docker-compose-rabbitmq-mssql/README.md
+++ b/docs/docker-compose-rabbitmq-mssql/README.md
@@ -266,7 +266,6 @@ This docker formation brings up the following docker containers:
 1. *[mcr.microsoft.com/mssql/server:2019-GA-ubuntu-16.04](https://github.com/Microsoft/mssql-docker)*
 1. *[senzing/adminer](https://github.com/Senzing/docker-adminer)*
 1. *[senzing/console](https://github.com/Senzing/docker-senzing-console)*
-1. *[senzing/entity-web-search-app-console](https://github.com/Senzing/entity-search-web-app-console)*
 1. *[senzing/entity-web-search-app](https://github.com/Senzing/entity-search-web-app)*
 1. *[senzing/init-container](https://github.com/Senzing/docker-init-container)*
 1. *[senzing/jupyter](https://github.com/Senzing/docker-jupyter)*

--- a/docs/docker-compose-rabbitmq-mysql/README.md
+++ b/docs/docker-compose-rabbitmq-mysql/README.md
@@ -245,7 +245,6 @@ This docker formation brings up the following docker containers:
 1. *[mysql](https://github.com/docker-library/mysql)*
 1. *[phpmyadmin/phpmyadmin](https://github.com/phpmyadmin/docker)*
 1. *[senzing/console](https://github.com/Senzing/docker-senzing-console)*
-1. *[senzing/entity-web-search-app-console](https://github.com/Senzing/entity-search-web-app-console)*
 1. *[senzing/entity-web-search-app](https://github.com/Senzing/entity-search-web-app)*
 1. *[senzing/redoer](https://github.com/Senzing/redoer)*
 1. *[senzing/senzing-poc-server](https://github.com/Senzing/senzing-poc-server)*

--- a/docs/docker-compose-rabbitmq-postgresql-advanced/README.md
+++ b/docs/docker-compose-rabbitmq-postgresql-advanced/README.md
@@ -343,7 +343,6 @@ This docker formation brings up the following docker containers:
 1. *[busybox](https://hub.docker.com/_/busybox)*
 1. *[dpage/pgadmin4](https://hub.docker.com/r/dpage/pgadmin4)*
 1. *[senzing/console](https://github.com/Senzing/docker-senzing-console)*
-1. *[senzing/entity-web-search-app-console](https://github.com/Senzing/entity-search-web-app-console)*
 1. *[senzing/entity-web-search-app](https://github.com/Senzing/entity-search-web-app)*
 1. *[senzing/jupyter](https://github.com/Senzing/docker-jupyter)*
 1. *[senzing/redoer](https://github.com/Senzing/redoer)*

--- a/docs/docker-compose-rabbitmq-postgresql-minimal/README.md
+++ b/docs/docker-compose-rabbitmq-postgresql-minimal/README.md
@@ -221,7 +221,6 @@ This docker formation brings up the following docker containers:
 
 1. *[bitnami/postgres](https://github.com/bitnami/containers/tree/main/bitnami/postgresql)*
 1. *[bitnami/rabbitmq](https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq)*
-1. *[senzing/entity-web-search-app-console](https://github.com/Senzing/entity-search-web-app-console)*
 1. *[senzing/entity-web-search-app](https://github.com/Senzing/entity-search-web-app)*
 1. *[senzing/redoer](https://github.com/Senzing/redoer)*
 1. *[senzing/senzing-poc-server](https://github.com/Senzing/senzing-poc-server)*

--- a/docs/docker-compose-rabbitmq-postgresql/README.md
+++ b/docs/docker-compose-rabbitmq-postgresql/README.md
@@ -263,7 +263,6 @@ This docker formation brings up the following docker containers:
 1. *[busybox](https://hub.docker.com/_/busybox)*
 1. *[dpage/pgadmin4](https://hub.docker.com/r/dpage/pgadmin4)*
 1. *[senzing/console](https://github.com/Senzing/docker-senzing-console)*
-1. *[senzing/entity-web-search-app-console](https://github.com/Senzing/entity-search-web-app-console)*
 1. *[senzing/entity-web-search-app](https://github.com/Senzing/entity-search-web-app)*
 1. *[senzing/jupyter](https://github.com/Senzing/docker-jupyter)*
 1. *[senzing/redoer](https://github.com/Senzing/redoer)*

--- a/docs/docker-compose-rabbitmq-sqlite-advanced/README.md
+++ b/docs/docker-compose-rabbitmq-sqlite-advanced/README.md
@@ -331,7 +331,6 @@ This docker formation brings up the following docker containers:
 1. *[bitnami/rabbitmq](https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq)*
 1. *[coleifer/sqlite-web](https://github.com/coleifer/sqlite-web)*
 1. *[senzing/console](https://github.com/Senzing/docker-senzing-console)*
-1. *[senzing/entity-web-search-app-console](https://github.com/Senzing/entity-search-web-app-console)*
 1. *[senzing/entity-web-search-app](https://github.com/Senzing/entity-search-web-app)*
 1. *[senzing/jupyter](https://github.com/Senzing/docker-jupyter)*
 1. *[senzing/redoer](https://github.com/Senzing/redoer)*

--- a/docs/docker-compose-rabbitmq-sqlite/README.md
+++ b/docs/docker-compose-rabbitmq-sqlite/README.md
@@ -259,7 +259,6 @@ This docker formation brings up the following docker containers:
 1. *[bitnami/rabbitmq](https://github.com/bitnami/containers/tree/main/bitnami/rabbitmq)*
 1. *[coleifer/sqlite-web](https://github.com/coleifer/sqlite-web)*
 1. *[senzing/console](https://github.com/Senzing/docker-senzing-console)*
-1. *[senzing/entity-web-search-app-console](https://github.com/Senzing/entity-search-web-app-console)*
 1. *[senzing/entity-web-search-app](https://github.com/Senzing/entity-search-web-app)*
 1. *[senzing/jupyter](https://github.com/Senzing/docker-jupyter)*
 1. *[senzing/redoer](https://github.com/Senzing/redoer)*

--- a/docs/docker-compose-sqs-postgresql-advanced/README.md
+++ b/docs/docker-compose-sqs-postgresql-advanced/README.md
@@ -361,7 +361,6 @@ This docker formation brings up the following docker containers:
 1. *[bitnami/postgres](https://github.com/bitnami/containers/tree/main/bitnami/postgresql)*
 1. *[dpage/pgadmin4](https://hub.docker.com/r/dpage/pgadmin4)*
 1. *[senzing/console](https://github.com/Senzing/docker-senzing-console)*
-1. *[senzing/entity-web-search-app-console](https://github.com/Senzing/entity-search-web-app-console)*
 1. *[senzing/entity-web-search-app](https://github.com/Senzing/entity-search-web-app)*
 1. *[senzing/jupyter](https://github.com/Senzing/docker-jupyter)*
 1. *[senzing/redoer](https://github.com/Senzing/redoer)*

--- a/docs/docker-compose-sqs-postgresql/README.md
+++ b/docs/docker-compose-sqs-postgresql/README.md
@@ -277,7 +277,6 @@ This docker formation brings up the following docker containers:
 1. *[bitnami/postgres](https://github.com/bitnami/containers/tree/main/bitnami/postgresql)*
 1. *[dpage/pgadmin4](https://hub.docker.com/r/dpage/pgadmin4)*
 1. *[senzing/console](https://github.com/Senzing/docker-senzing-console)*
-1. *[senzing/entity-web-search-app-console](https://github.com/Senzing/entity-search-web-app-console)*
 1. *[senzing/entity-web-search-app](https://github.com/Senzing/entity-search-web-app)*
 1. *[senzing/jupyter](https://github.com/Senzing/docker-jupyter)*
 1. *[senzing/redoer](https://github.com/Senzing/redoer)*

--- a/resources/db2/docker-compose-kafka-db2-again.yaml
+++ b/resources/db2/docker-compose-kafka-db2-again.yaml
@@ -248,7 +248,6 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
 #     See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
@@ -257,30 +256,12 @@ services:
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
       SENZING_WEB_SERVER_PORT: 8251
       SENZING_WEB_SERVER_STREAM_CLIENT_URL: wss://senzing-poc-server:8250/ws
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
     image: senzing/entity-search-web-app:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP:-latest}
     networks:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
-    restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_DATA_VERSION_DIR:-/opt/senzing/data/3.0.0}:/opt/senzing/data
-      - ${SENZING_ETC_DIR:-/etc/opt/senzing}:/etc/opt/senzing
-      - ${SENZING_G2_DIR:-/opt/senzing/g2}:/opt/senzing/g2
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
     restart: always
 
   sshd:

--- a/resources/db2/docker-compose-kafka-db2-api-server.yaml
+++ b/resources/db2/docker-compose-kafka-db2-api-server.yaml
@@ -278,7 +278,6 @@ services:
     container_name: senzing-webapp
     depends_on:
       - api
-      - webapp-console
     environment:
 #     See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-api-server:8250
@@ -287,30 +286,12 @@ services:
       SENZING_WEB_SERVER_API_PATH: /api
       SENZING_WEB_SERVER_PORT: 8251
       SENZING_WEB_SERVER_URL: http://localhost:8251
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
     image: senzing/entity-search-web-app:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP:-latest}
     networks:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
-    restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_DATA_VERSION_DIR:-/opt/senzing/data/3.0.0}:/opt/senzing/data
-      - ${SENZING_ETC_DIR:-/etc/opt/senzing}:/etc/opt/senzing
-      - ${SENZING_G2_DIR:-/opt/senzing/g2}:/opt/senzing/g2
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
     restart: always
 
   sshd:

--- a/resources/db2/docker-compose-kafka-db2.yaml
+++ b/resources/db2/docker-compose-kafka-db2.yaml
@@ -281,7 +281,6 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
 #     See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
@@ -290,30 +289,12 @@ services:
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
       SENZING_WEB_SERVER_PORT: 8251
       SENZING_WEB_SERVER_STREAM_CLIENT_URL: wss://senzing-poc-server:8250/ws
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
     image: senzing/entity-search-web-app:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP:-latest}
     networks:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
-    restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_DATA_VERSION_DIR:-/opt/senzing/data/3.0.0}:/opt/senzing/data
-      - ${SENZING_ETC_DIR:-/etc/opt/senzing}:/etc/opt/senzing
-      - ${SENZING_G2_DIR:-/opt/senzing/g2}:/opt/senzing/g2
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
     restart: always
 
   sshd:

--- a/resources/db2/docker-compose-rabbitmq-db2-again.yaml
+++ b/resources/db2/docker-compose-rabbitmq-db2-again.yaml
@@ -228,7 +228,6 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
 #     See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
@@ -237,30 +236,12 @@ services:
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
       SENZING_WEB_SERVER_PORT: 8251
       SENZING_WEB_SERVER_STREAM_CLIENT_URL: wss://senzing-poc-server:8250/ws
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
     image: senzing/entity-search-web-app:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP:-latest}
     networks:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
-    restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_DATA_VERSION_DIR:-/opt/senzing/data/3.0.0}:/opt/senzing/data
-      - ${SENZING_ETC_DIR:-/etc/opt/senzing}:/etc/opt/senzing
-      - ${SENZING_G2_DIR:-/opt/senzing/g2}:/opt/senzing/g2
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
     restart: always
 
   sshd:

--- a/resources/db2/docker-compose-rabbitmq-db2-api-server.yaml
+++ b/resources/db2/docker-compose-rabbitmq-db2-api-server.yaml
@@ -254,7 +254,6 @@ services:
     container_name: senzing-webapp
     depends_on:
       - api
-      - webapp-console
     environment:
 #     See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-api-server:8250
@@ -263,30 +262,12 @@ services:
       SENZING_WEB_SERVER_API_PATH: /api
       SENZING_WEB_SERVER_PORT: 8251
       SENZING_WEB_SERVER_URL: http://localhost:8251
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
     image: senzing/entity-search-web-app:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP:-latest}
     networks:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
-    restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_DATA_VERSION_DIR:-/opt/senzing/data/3.0.0}:/opt/senzing/data
-      - ${SENZING_ETC_DIR:-/etc/opt/senzing}:/etc/opt/senzing
-      - ${SENZING_G2_DIR:-/opt/senzing/g2}:/opt/senzing/g2
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
     restart: always
 
   sshd:

--- a/resources/db2/docker-compose-rabbitmq-db2-cluster.yaml
+++ b/resources/db2/docker-compose-rabbitmq-db2-cluster.yaml
@@ -430,7 +430,6 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
 #     See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
@@ -439,30 +438,12 @@ services:
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
       SENZING_WEB_SERVER_PORT: 8251
       SENZING_WEB_SERVER_STREAM_CLIENT_URL: wss://senzing-poc-server:8250/ws
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
     image: senzing/entity-search-web-app:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP:-latest}
     networks:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
-    restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_DATA_VERSION_DIR:-/opt/senzing/data/3.0.0}:/opt/senzing/data
-      - ${SENZING_ETC_DIR:-/etc/opt/senzing}:/etc/opt/senzing
-      - ${SENZING_G2_DIR:-/opt/senzing/g2}:/opt/senzing/g2
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
     restart: always
 
   jupyter:

--- a/resources/db2/docker-compose-rabbitmq-db2.yaml
+++ b/resources/db2/docker-compose-rabbitmq-db2.yaml
@@ -261,7 +261,6 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
 #     See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
@@ -270,30 +269,12 @@ services:
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
       SENZING_WEB_SERVER_PORT: 8251
       SENZING_WEB_SERVER_STREAM_CLIENT_URL: wss://senzing-poc-server:8250/ws
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
     image: senzing/entity-search-web-app:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP:-latest}
     networks:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
-    restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_DATA_VERSION_DIR:-/opt/senzing/data/3.0.0}:/opt/senzing/data
-      - ${SENZING_ETC_DIR:-/etc/opt/senzing}:/etc/opt/senzing
-      - ${SENZING_G2_DIR:-/opt/senzing/g2}:/opt/senzing/g2
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
     restart: always
 
   sshd:

--- a/resources/mssql/docker-compose-kafka-mssql-api-server.yaml
+++ b/resources/mssql/docker-compose-kafka-mssql-api-server.yaml
@@ -347,7 +347,6 @@ services:
     container_name: senzing-webapp
     depends_on:
       - api
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-api-server:8250
@@ -356,42 +355,13 @@ services:
       SENZING_WEB_SERVER_API_PATH: /api
       SENZING_WEB_SERVER_PORT: 8251
       SENZING_WEB_SERVER_URL: http://localhost:8251
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
     image: senzing/entity-search-web-app:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP:-latest}
     networks:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      ODBCINI: /var/opt/senzing/mssql/odbc.ini
-      ODBCSYSINI: /opt/microsoft/msodbcsql17/etc
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "mssql://${MSSQL_USERNAME:-sa}:${MSSQL_SA_PASSWORD:-Passw0rd}@${MSSQL_DATABASE:-G2}"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   sshd:
     cap_add:

--- a/resources/mssql/docker-compose-kafka-mssql.yaml
+++ b/resources/mssql/docker-compose-kafka-mssql.yaml
@@ -348,11 +348,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -363,36 +361,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      ODBCINI: /var/opt/senzing/mssql/odbc.ini
-      ODBCSYSINI: /opt/microsoft/msodbcsql17/etc
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "mssql://${MSSQL_USERNAME:-sa}:${MSSQL_SA_PASSWORD:-Passw0rd}@${MSSQL_DATABASE:-G2}"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   sshd:
     cap_add:

--- a/resources/mssql/docker-compose-rabbitmq-mssql-api-server.yaml
+++ b/resources/mssql/docker-compose-rabbitmq-mssql-api-server.yaml
@@ -323,7 +323,6 @@ services:
     container_name: senzing-webapp
     depends_on:
       - api
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-api-server:8250
@@ -332,42 +331,13 @@ services:
       SENZING_WEB_SERVER_API_PATH: /api
       SENZING_WEB_SERVER_PORT: 8251
       SENZING_WEB_SERVER_URL: http://localhost:8251
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
     image: senzing/entity-search-web-app:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP:-latest}
     networks:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      ODBCINI: /var/opt/senzing/mssql/odbc.ini
-      ODBCSYSINI: /opt/microsoft/msodbcsql17/etc
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "mssql://${MSSQL_USERNAME:-sa}:${MSSQL_SA_PASSWORD:-Passw0rd}@${MSSQL_DATABASE:-G2}"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   sshd:
     cap_add:

--- a/resources/mssql/docker-compose-rabbitmq-mssql-cluster.yaml
+++ b/resources/mssql/docker-compose-rabbitmq-mssql-cluster.yaml
@@ -588,11 +588,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -603,36 +601,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      ODBCINI: /var/opt/senzing/mssql/odbc.ini
-      ODBCSYSINI: /opt/microsoft/msodbcsql17/etc
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "mssql://${MSSQL_USERNAME:-sa}:${MSSQL_SA_PASSWORD:-Passw0rd}@${MSSQL_DATABASE:-G2}"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   sshd:
     cap_add:

--- a/resources/mssql/docker-compose-rabbitmq-mssql.yaml
+++ b/resources/mssql/docker-compose-rabbitmq-mssql.yaml
@@ -328,11 +328,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -343,36 +341,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      ODBCINI: /var/opt/senzing/mssql/odbc.ini
-      ODBCSYSINI: /opt/microsoft/msodbcsql17/etc
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "mssql://${MSSQL_USERNAME:-sa}:${MSSQL_SA_PASSWORD:-Passw0rd}@${MSSQL_DATABASE:-G2}"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   sshd:
     cap_add:

--- a/resources/mysql/docker-compose-kafka-mysql-api-server.yaml
+++ b/resources/mysql/docker-compose-kafka-mysql-api-server.yaml
@@ -249,7 +249,6 @@ services:
     container_name: senzing-webapp
     depends_on:
       - api
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-api-server:8250
@@ -258,40 +257,13 @@ services:
       SENZING_WEB_SERVER_API_PATH: /api
       SENZING_WEB_SERVER_PORT: 8251
       SENZING_WEB_SERVER_URL: http://localhost:8251
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
     image: senzing/entity-search-web-app:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP:-latest}
     networks:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "mysql://${MYSQL_USERNAME:-g2}:${MYSQL_PASSWORD:-g2}@${MYSQL_HOST:-senzing-mysql}:${MYSQL_PORT:-3306}/?schema=${MYSQL_DATABASE:-G2}"
-          }
-        }
-    image: senzing/entity-search-web-app-console-mysql:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   sshd:
     cap_add:

--- a/resources/mysql/docker-compose-kafka-mysql.yaml
+++ b/resources/mysql/docker-compose-kafka-mysql.yaml
@@ -252,11 +252,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -267,34 +265,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "mysql://${MYSQL_USERNAME:-g2}:${MYSQL_PASSWORD:-g2}@${MYSQL_HOST:-senzing-mysql}:${MYSQL_PORT:-3306}/?schema=${MYSQL_DATABASE:-G2}"
-          }
-        }
-    image: senzing/entity-search-web-app-console-mysql:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   sshd:
     cap_add:

--- a/resources/mysql/docker-compose-rabbitmq-mysql-api-server.yaml
+++ b/resources/mysql/docker-compose-rabbitmq-mysql-api-server.yaml
@@ -226,7 +226,6 @@ services:
     container_name: senzing-webapp
     depends_on:
       - api
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-api-server:8250
@@ -235,40 +234,13 @@ services:
       SENZING_WEB_SERVER_API_PATH: /api
       SENZING_WEB_SERVER_PORT: 8251
       SENZING_WEB_SERVER_URL: http://localhost:8251
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
     image: senzing/entity-search-web-app:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP:-latest}
     networks:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "mysql://${MYSQL_USERNAME:-g2}:${MYSQL_PASSWORD:-g2}@${MYSQL_HOST:-senzing-mysql}:${MYSQL_PORT:-3306}/?schema=${MYSQL_DATABASE:-G2}"
-          }
-        }
-    image: senzing/entity-search-web-app-console-mysql:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   sshd:
     cap_add:

--- a/resources/mysql/docker-compose-rabbitmq-mysql.yaml
+++ b/resources/mysql/docker-compose-rabbitmq-mysql.yaml
@@ -233,11 +233,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -248,34 +246,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "mysql://${MYSQL_USERNAME:-g2}:${MYSQL_PASSWORD:-g2}@${MYSQL_HOST:-senzing-mysql}:${MYSQL_PORT:-3306}/?schema=${MYSQL_DATABASE:-G2}"
-          }
-        }
-    image: senzing/entity-search-web-app-console-mysql:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   sshd:
     cap_add:

--- a/resources/postgresql/docker-compose-kafka-postgresql-api-server.yaml
+++ b/resources/postgresql/docker-compose-kafka-postgresql-api-server.yaml
@@ -311,11 +311,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - api
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-api-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: JWT
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -326,34 +324,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-kafka-postgresql-redoer-kafka-withinfo.yaml
+++ b/resources/postgresql/docker-compose-kafka-postgresql-redoer-kafka-withinfo.yaml
@@ -401,11 +401,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -416,34 +414,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-kafka-postgresql-redoer-kafka.yaml
+++ b/resources/postgresql/docker-compose-kafka-postgresql-redoer-kafka.yaml
@@ -349,11 +349,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -364,34 +362,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-kafka-postgresql-redoer-withinfo.yaml
+++ b/resources/postgresql/docker-compose-kafka-postgresql-redoer-withinfo.yaml
@@ -369,11 +369,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -384,34 +382,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-kafka-postgresql-withinfo.yaml
+++ b/resources/postgresql/docker-compose-kafka-postgresql-withinfo.yaml
@@ -349,11 +349,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -364,34 +362,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-kafka-postgresql.yaml
+++ b/resources/postgresql/docker-compose-kafka-postgresql.yaml
@@ -315,11 +315,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -330,34 +328,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-rabbitmq-postgresql-api-server.yaml
+++ b/resources/postgresql/docker-compose-rabbitmq-postgresql-api-server.yaml
@@ -288,11 +288,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - api
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-api-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: JWT
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -303,34 +301,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-rabbitmq-postgresql-cluster.yaml
+++ b/resources/postgresql/docker-compose-rabbitmq-postgresql-cluster.yaml
@@ -491,11 +491,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -506,50 +504,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "HYBRID",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}"
-          },
-          "C1": {
-            "CLUSTER_SIZE": "1",
-            "DB_1": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres-res}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}"
-          },
-          "C2": {
-            "CLUSTER_SIZE": "1",
-            "DB_1": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres-libfeat}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}"
-          },
-          "HYBRID": {
-            "RES_FEAT": "C1",
-            "RES_FEAT_EKEY": "C1",
-            "RES_FEAT_LKEY": "C1",
-            "RES_FEAT_STAT": "C1",
-            "LIB_FEAT": "C2",
-            "LIB_FEAT_HKEY": "C2"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-rabbitmq-postgresql-debug.yaml
+++ b/resources/postgresql/docker-compose-rabbitmq-postgresql-debug.yaml
@@ -308,11 +308,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -323,34 +321,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-rabbitmq-postgresql-minimal.yaml
+++ b/resources/postgresql/docker-compose-rabbitmq-postgresql-minimal.yaml
@@ -203,11 +203,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -218,34 +216,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
 networks:
   senzing:

--- a/resources/postgresql/docker-compose-rabbitmq-postgresql-path-based-routing.yaml
+++ b/resources/postgresql/docker-compose-rabbitmq-postgresql-path-based-routing.yaml
@@ -297,12 +297,10 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250/api
       SENZING_BASE_URL_ENTITY_SEARCH_WEB_APP: /app
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_API_PATH: /api
@@ -315,34 +313,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-rabbitmq-postgresql-redoer-rabbitmq-withinfo.yaml
+++ b/resources/postgresql/docker-compose-rabbitmq-postgresql-redoer-rabbitmq-withinfo.yaml
@@ -396,11 +396,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -411,34 +409,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-rabbitmq-postgresql-redoer-rabbitmq.yaml
+++ b/resources/postgresql/docker-compose-rabbitmq-postgresql-redoer-rabbitmq.yaml
@@ -335,11 +335,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -350,34 +348,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-rabbitmq-postgresql-redoer-withinfo.yaml
+++ b/resources/postgresql/docker-compose-rabbitmq-postgresql-redoer-withinfo.yaml
@@ -359,11 +359,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -374,34 +372,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-rabbitmq-postgresql-with-ELK.yaml
+++ b/resources/postgresql/docker-compose-rabbitmq-postgresql-with-ELK.yaml
@@ -443,11 +443,9 @@ services:
     depends_on:
       - pocserver
       - logstash
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -463,39 +461,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    logging:
-      driver: gelf
-      options:
-        gelf-address: "udp://localhost:12201"
-        tag: "senzing-webapp-console"
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-rabbitmq-postgresql-withinfo.yaml
+++ b/resources/postgresql/docker-compose-rabbitmq-postgresql-withinfo.yaml
@@ -336,11 +336,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -351,34 +349,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-rabbitmq-postgresql.yaml
+++ b/resources/postgresql/docker-compose-rabbitmq-postgresql.yaml
@@ -296,11 +296,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -311,34 +309,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-sqs-postgresql-api-server.yaml
+++ b/resources/postgresql/docker-compose-sqs-postgresql-api-server.yaml
@@ -268,11 +268,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - api
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-api-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: JWT
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -283,34 +281,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-sqs-postgresql-redoer-sqs-withinfo.yaml
+++ b/resources/postgresql/docker-compose-sqs-postgresql-redoer-sqs-withinfo.yaml
@@ -372,11 +372,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -387,34 +385,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-sqs-postgresql-redoer-sqs.yaml
+++ b/resources/postgresql/docker-compose-sqs-postgresql-redoer-sqs.yaml
@@ -310,11 +310,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -325,34 +323,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-sqs-postgresql-redoer-withinfo.yaml
+++ b/resources/postgresql/docker-compose-sqs-postgresql-redoer-withinfo.yaml
@@ -337,11 +337,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -352,34 +350,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-sqs-postgresql-withinfo.yaml
+++ b/resources/postgresql/docker-compose-sqs-postgresql-withinfo.yaml
@@ -314,11 +314,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -329,34 +327,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/postgresql/docker-compose-sqs-postgresql.yaml
+++ b/resources/postgresql/docker-compose-sqs-postgresql.yaml
@@ -269,11 +269,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -284,34 +282,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "SQL",
-            "CONNECTION": "postgresql://${POSTGRES_USERNAME:-postgres}:${POSTGRES_PASSWORD:-postgres}@${POSTGRES_HOST:-senzing-postgres}:${POSTGRES_PORT:-5432}:${POSTGRES_DB:-G2}/"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/sqlite/docker-compose-kafka-sqlite-api-server.yaml
+++ b/resources/sqlite/docker-compose-kafka-sqlite-api-server.yaml
@@ -237,7 +237,6 @@ services:
     container_name: senzing-webapp
     depends_on:
       - api
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-api-server:8250
@@ -246,39 +245,13 @@ services:
       SENZING_WEB_SERVER_API_PATH: /api
       SENZING_WEB_SERVER_PORT: 8251
       SENZING_WEB_SERVER_URL: http://localhost:8251
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
     image: senzing/entity-search-web-app:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP:-latest}
     networks:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "CONNECTION": "sqlite3://na:na@/var/opt/senzing/sqlite/G2C.db"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/sqlite/docker-compose-kafka-sqlite.yaml
+++ b/resources/sqlite/docker-compose-kafka-sqlite.yaml
@@ -240,11 +240,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -255,33 +253,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "CONNECTION": "sqlite3://na:na@/var/opt/senzing/sqlite/G2C.db"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/sqlite/docker-compose-rabbitmq-sqlite-api-server.yaml
+++ b/resources/sqlite/docker-compose-rabbitmq-sqlite-api-server.yaml
@@ -214,7 +214,6 @@ services:
     container_name: senzing-webapp
     depends_on:
       - api
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-api-server:8250
@@ -223,39 +222,13 @@ services:
       SENZING_WEB_SERVER_API_PATH: /api
       SENZING_WEB_SERVER_PORT: 8251
       SENZING_WEB_SERVER_URL: http://localhost:8251
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
     image: senzing/entity-search-web-app:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP:-latest}
     networks:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "CONNECTION": "sqlite3://na:na@/var/opt/senzing/sqlite/G2C.db"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/sqlite/docker-compose-rabbitmq-sqlite-cluster.yaml
+++ b/resources/sqlite/docker-compose-rabbitmq-sqlite-cluster.yaml
@@ -331,7 +331,6 @@ services:
     container_name: senzing-webapp
     depends_on:
       - api
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-api-server:8250
@@ -340,56 +339,13 @@ services:
       SENZING_WEB_SERVER_API_PATH: /api
       SENZING_WEB_SERVER_PORT: 8251
       SENZING_WEB_SERVER_URL: http://localhost:8251
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
     image: senzing/entity-search-web-app:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP:-latest}
     networks:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "BACKEND": "HYBRID",
-            "CONNECTION": "sqlite3://na:na@/var/opt/senzing/sqlite/G2C.db"
-          },
-          "C1": {
-            "CLUSTER_SIZE": "1",
-            "DB_1": "sqlite3://na:na@/var/opt/senzing/sqlite/G2C_RES.db"
-          },
-          "C2": {
-            "CLUSTER_SIZE": "1",
-            "DB_1": "sqlite3://na:na@/var/opt/senzing/sqlite/G2C_LIBFEAT.db"
-          },
-          "HYBRID": {
-            "RES_FEAT": "C1",
-            "RES_FEAT_EKEY": "C1",
-            "RES_FEAT_LKEY": "C1",
-            "RES_FEAT_STAT": "C1",
-            "LIB_FEAT": "C2",
-            "LIB_FEAT_HKEY": "C2"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/sqlite/docker-compose-rabbitmq-sqlite-debug.yaml
+++ b/resources/sqlite/docker-compose-rabbitmq-sqlite-debug.yaml
@@ -222,11 +222,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -237,33 +235,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "CONNECTION": "sqlite3://na:na@/var/opt/senzing/sqlite/G2C.db"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/sqlite/docker-compose-rabbitmq-sqlite-governor.yaml
+++ b/resources/sqlite/docker-compose-rabbitmq-sqlite-governor.yaml
@@ -223,11 +223,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -238,33 +236,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "CONNECTION": "sqlite3://na:na@/var/opt/senzing/sqlite/G2C.db"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter

--- a/resources/sqlite/docker-compose-rabbitmq-sqlite.yaml
+++ b/resources/sqlite/docker-compose-rabbitmq-sqlite.yaml
@@ -221,11 +221,9 @@ services:
     container_name: senzing-webapp
     depends_on:
       - pocserver
-      - webapp-console
     environment:
       # See https://github.com/Senzing/entity-search-web-app#configuration
       SENZING_API_SERVER_URL: http://senzing-poc-server:8250
-      SENZING_CONSOLE_SERVER_URL: ws://senzing-webapp-console:8257
       SENZING_WEB_SERVER_ADMIN_AUTH_MODE: NONE
       SENZING_WEB_SERVER_ADMIN_AUTH_PATH: http://senzing-webapp:8251
       SENZING_WEB_SERVER_INTERNAL_URL: http://senzing-webapp:8251
@@ -236,33 +234,8 @@ services:
       - senzing
     ports:
       - 8251:8251
-      - 8257:8257
     read_only: true
     restart: always
-
-  webapp-console:
-    container_name: senzing-webapp-console
-    environment:
-      SENZING_CONSOLE_SERVER_PORT: 8257
-      SENZING_ENGINE_CONFIGURATION_JSON: >-
-        {
-          "PIPELINE": {
-            "CONFIGPATH": "/etc/opt/senzing",
-            "LICENSESTRINGBASE64": "${SENZING_LICENSE_BASE64_ENCODED}",
-            "RESOURCEPATH": "/opt/senzing/g2/resources",
-            "SUPPORTPATH": "/opt/senzing/data"
-          },
-          "SQL": {
-            "CONNECTION": "sqlite3://na:na@/var/opt/senzing/sqlite/G2C.db"
-          }
-        }
-    image: senzing/entity-search-web-app-console:${SENZING_DOCKER_IMAGE_VERSION_ENTITY_SEARCH_WEB_APP_CONSOLE:-latest}
-    networks:
-      - senzing
-    restart: always
-    user: ${SENZING_UID:-1001}:${SENZING_GID:-1001}
-    volumes:
-      - ${SENZING_VAR_DIR:-/var/opt/senzing}:/var/opt/senzing
 
   jupyter:
     container_name: senzing-jupyter


### PR DESCRIPTION
# Pull request questions

## Which issue does this address

Issue number: #133

## Why was change needed

We will be removing the [entity-search-web-app-console](https://github.com/Senzing/entity-search-web-app-console) from active maintenance.

The current and previous releases of senzing/entity-search-web-app are smart enough to not enable the links and interfaces when two variables are removed from the startup yaml.

## What does change improve

- complexity. 
- dependency security.
